### PR TITLE
Update fstab with new mountpoint

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,6 +1,6 @@
 mountpoints:
   /:
-    url: https://github.com/{org}/{site}
+    url: https://content.da.live/dipakder-git/storefront/
     type: markup
 
 folders:


### PR DESCRIPTION
Fix #<gh-issue-id> (N/A)

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/

Updated `fstab.yaml` to point the root mountpoint (`/`) to the new content URL `https://content.da.live/dipakder-git/storefront/`. This resolves the issue where the site's fstab was not pointing to the new content as required by the Adobe Commerce Site Creator.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcc9471d-7309-4d15-b75a-1d1e82d63f25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcc9471d-7309-4d15-b75a-1d1e82d63f25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

