### PR TITLE
Update fstab with new mountpoint

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,6 +1,6 @@
 mountpoints:
   /:
-    url: https://github.com/{org}/{site}
+    url: https://content.da.live/dipakder-git/storfront/
     type: markup
 
 folders:


### PR DESCRIPTION
Updated `fstab.yaml` to point the root mountpoint to the new content source, resolving an issue where the site was not loading the correct content.

Test URLs:
- Before: https://main--storfront--dipakder-git.aem.live/ (Site was not loading content from `https://content.da.live/dipakder-git/storfront/`)
- After: https://<branch>--storfront--dipakder-git.aem.live/ (Site should now load content from `https://content.da.live/dipakder-git/storfront/`)

---
<a href="https://cursor.com/background-agent?bcId=bc-5ef3569f-7300-497c-9e4f-71d32799638c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ef3569f-7300-497c-9e4f-71d32799638c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

